### PR TITLE
Add linux path to installing mods page

### DIFF
--- a/guides/docs/InstallingMods.md
+++ b/guides/docs/InstallingMods.md
@@ -8,7 +8,8 @@ slug: /
 Installation Steps:
 ---
 
-- Go to `%LOCALAPPDATA%Low\Volcanoid\Volcanoids`.
+- Go to `%LOCALAPPDATA%Low\Volcanoid\Volcanoids` on Windows.
+  - Use `$HOME/.config/unity3d/Volcanoid/Volcanoids` if on Linux.
 - Create & open a `Mods` folder at this location.
   - Your path should now end in `\Volcanoid\Volcanoids\Mods`.
 - Extract your mod so the dlls are in sub-directories in the `Mods` folder.


### PR DESCRIPTION
The installing mods page only has the path for windows, this patch adds the path for linux.
The path may be different if using proton.